### PR TITLE
fix: redundant "then" usage in evaluation.feature

### DIFF
--- a/features/evaluation.feature
+++ b/features/evaluation.feature
@@ -53,10 +53,10 @@ Feature: Flag evaluation
   # errors
   Scenario: Flag not found
     When a non-existent string flag with key "missing-flag" is evaluated with details and a default value "uh-oh"
-    Then then the default string value should be returned
+    Then the default string value should be returned
     And the reason should indicate an error and the error code should indicate a missing flag with "FLAG_NOT_FOUND"
 
   Scenario: Type error
     When a string flag with key "wrong-flag" is evaluated as an integer, with details and a default value 13
-    Then then the default integer value should be returned
+    Then the default integer value should be returned
     And the reason should indicate an error and the error code should indicate a type mismatch with "TYPE_MISMATCH"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- updates `Resolves based on context` and `Type error` scenarios, removing redundant "then" after the start of "Then" statement

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #10 
