### PR TITLE
chore: renovate regex manager to monitor FLAGD_VERSION in Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^Dockerfile$"],
+      "matchStrings": ["ghcr\\.io\\/open-feature\\/flagd:(?<currentValue>.*?)\\n"],
+      "depNameTemplate": "open-feature/flagd",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

Adds renovate config to monitor FLAGD_VERSION in Dockerfile

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #16 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

